### PR TITLE
catch exception to fix python2 compatibility

### DIFF
--- a/qstatpretty/config.py
+++ b/qstatpretty/config.py
@@ -1,4 +1,7 @@
-import configparser
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
 import os.path
 
 


### PR DESCRIPTION
Use a try-catch exception so that pstat will run without edits on python2
