### PR TITLE
Use defaults if no config file is available

### DIFF
--- a/qstatpretty/config.py
+++ b/qstatpretty/config.py
@@ -14,7 +14,17 @@ CONFIGS_ORDER = [
 
 def get_config(configs_order=CONFIGS_ORDER):
     parser = configparser.SafeConfigParser()
-    parser.read(configs_order)
-    cfg = parser.items('defaults')
+    try:
+        parser.read(configs_order)
+        cfg = parser.items('defaults')
+    except:
+        cfg = {
+            'flavor': 'gridengine',
+            'table_algorithm': 'grow',
+            'delimiters': 'minimal',
+            'source': 'local',
+            'source_ssh_hostname': '',
+            'source_file_path': ''
+        }
 
     return dict(cfg)


### PR DESCRIPTION
Per-user and system-wide configuration files may not always be necessary.  Set defaults to use if no config file can be found rather than bombing out with an error.
