### PR TITLE
Fix UTF print encoding

### DIFF
--- a/qstatpretty/pretty.py
+++ b/qstatpretty/pretty.py
@@ -20,4 +20,4 @@ def pretty_table(jobs, table_format, terminal_width=ttysize.terminal_size()[0], 
 
     tbl = job_table(jobs, table_format)
     tbl, delimiters = table_algorithm(tbl, terminal_width, table_format, delimiters)
-    print(ttytable.pretty_table(tbl, table_format, delimiters=delimiters))
+    print(ttytable.pretty_table(tbl, table_format, delimiters=delimiters).encode('utf-8'))


### PR DESCRIPTION
Fixed the bug:

```
Traceback (most recent call last):
  File "/home/m/mchakrav/gdevenyi/bin/qstat-pretty/pstat", line 139, in <module>
    main()
  File "/home/m/mchakrav/gdevenyi/bin/qstat-pretty/pstat", line 118, in main
    qstatpretty.pretty.pretty_table(jobs, parser.table_columns, table_algorithm=ttyresize.TABLE_ALGORITHMS[opt.table_algorithm], delimiters=ttytable.DELIMITERS[opt.delimiters])
  File "/bg01/homescinet/m/mchakrav/gdevenyi/bin/qstat-pretty/qstatpretty/pretty.py", line 23, in pretty_table
    print(ttytable.pretty_table(tbl, table_format, delimiters=delimiters))
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2502' in position 36: ordinal not in range(128)
```
